### PR TITLE
Chris’s review

### DIFF
--- a/configuration/base.yaml
+++ b/configuration/base.yaml
@@ -1,4 +1,3 @@
-#! configuration/base.yaml
 server:
   port: 8000
 database:

--- a/configuration/local.yaml
+++ b/configuration/local.yaml
@@ -1,3 +1,2 @@
-#! configuration/local.yaml
 server:
   host: 127.0.01

--- a/configuration/production.yaml
+++ b/configuration/production.yaml
@@ -1,3 +1,2 @@
-#! configuration/production.yaml
 server:
   host: 0.0.0.0

--- a/src/database/connection.rs
+++ b/src/database/connection.rs
@@ -1,5 +1,3 @@
-//! src/utils/database/connection.rs
-
 use crate::database::mocks;
 use crate::database::queries;
 use crate::database::schema::{

--- a/src/database/connection.rs
+++ b/src/database/connection.rs
@@ -109,66 +109,60 @@ impl DatabaseConnection {
         queries::insert_requisition_lines(&self.pool, requisition_lines).await
     }
 
-    pub async fn get_store(&self, id: String) -> Result<StoreRow, sqlx::Error> {
+    pub async fn get_store(&self, id: &str) -> Result<StoreRow, sqlx::Error> {
         queries::select_store(&self.pool, id).await
     }
 
-    pub async fn get_name(&self, id: String) -> Result<NameRow, sqlx::Error> {
+    pub async fn get_name(&self, id: &str) -> Result<NameRow, sqlx::Error> {
         queries::select_name(&self.pool, id).await
     }
 
-    pub async fn get_item(&self, id: String) -> Result<ItemRow, sqlx::Error> {
+    pub async fn get_item(&self, id: &str) -> Result<ItemRow, sqlx::Error> {
         queries::select_item(&self.pool, id).await
     }
 
-    pub async fn get_item_line(&self, id: String) -> Result<ItemLineRow, sqlx::Error> {
+    pub async fn get_item_line(&self, id: &str) -> Result<ItemLineRow, sqlx::Error> {
         queries::select_item_line(&self.pool, id).await
     }
 
-    pub async fn get_requisition(&self, id: String) -> Result<RequisitionRow, sqlx::Error> {
+    pub async fn get_requisition(&self, id: &str) -> Result<RequisitionRow, sqlx::Error> {
         queries::select_requisition(&self.pool, id).await
     }
 
     #[allow(dead_code)]
-    pub async fn get_requisition_line(
-        &self,
-        id: String,
-    ) -> Result<RequisitionLineRow, sqlx::Error> {
+    pub async fn get_requisition_line(&self, id: &str) -> Result<RequisitionLineRow, sqlx::Error> {
         queries::select_requisition_line(&self.pool, id).await
     }
 
     pub async fn get_requisition_lines(
         &self,
-        requisition_id: String,
+        requisition_id: &str,
     ) -> Result<Vec<RequisitionLineRow>, sqlx::Error> {
         queries::select_requisition_lines(&self.pool, requisition_id).await
     }
 
     #[allow(dead_code)]
-    pub async fn get_transaction(&self, id: String) -> Result<TransactionRow, sqlx::Error> {
+    pub async fn get_transaction(&self, id: &str) -> Result<TransactionRow, sqlx::Error> {
         queries::select_transaction(&self.pool, id).await
     }
 
     #[allow(dead_code)]
     pub async fn get_transactions(
         &self,
-        name_id: String,
+        name_id: &str,
     ) -> Result<Vec<TransactionRow>, sqlx::Error> {
         queries::select_transactions(&self.pool, name_id).await
     }
 
     #[allow(dead_code)]
-    pub async fn get_transaction_line(
-        &self,
-        id: String,
-    ) -> Result<TransactionLineRow, sqlx::Error> {
+    pub async fn get_transaction_line(&self, id: &str) -> Result<TransactionLineRow, sqlx::Error> {
         queries::select_transaction_line(&self.pool, id).await
     }
 
     #[allow(dead_code)]
     pub async fn get_transaction_lines(
         &self,
-        transact_id: String,
+        transact_id: &str,
     ) -> Result<Vec<TransactionLineRow>, sqlx::Error> {
         queries::select_transaction_lines(&self.pool, transact_id).await
     }

--- a/src/database/connection.rs
+++ b/src/database/connection.rs
@@ -16,27 +16,27 @@ impl DatabaseConnection {
     }
 
     pub async fn insert_mock_data(&self) -> Result<(), sqlx::Error> {
-        self.create_names(mocks::mock_names())
+        self.create_names(&mocks::mock_names())
             .await
             .expect("Failed to insert mock name data");
 
-        self.create_stores(mocks::mock_stores())
+        self.create_stores(&mocks::mock_stores())
             .await
             .expect("Failed to insert mock store data");
 
-        self.create_items(mocks::mock_items())
+        self.create_items(&mocks::mock_items())
             .await
             .expect("Failed to insert mock item data");
 
-        self.create_item_lines(mocks::mock_item_lines())
+        self.create_item_lines(&mocks::mock_item_lines())
             .await
             .expect("Failed to insert mock item line data");
 
-        self.create_requisitions(mocks::mock_requisitions())
+        self.create_requisitions(&mocks::mock_requisitions())
             .await
             .expect("Failed to insert mock requisition data");
 
-        self.create_requisition_lines(mocks::mock_requisition_lines())
+        self.create_requisition_lines(&mocks::mock_requisition_lines())
             .await
             .expect("Failed to insert mock requisition line data");
 
@@ -49,7 +49,7 @@ impl DatabaseConnection {
     }
 
     #[allow(dead_code)]
-    pub async fn create_stores(&self, stores: Vec<StoreRow>) -> Result<(), sqlx::Error> {
+    pub async fn create_stores(&self, stores: &[StoreRow]) -> Result<(), sqlx::Error> {
         queries::insert_stores(&self.pool, stores).await
     }
 
@@ -59,7 +59,7 @@ impl DatabaseConnection {
     }
 
     #[allow(dead_code)]
-    pub async fn create_names(&self, names: Vec<NameRow>) -> Result<(), sqlx::Error> {
+    pub async fn create_names(&self, names: &[NameRow]) -> Result<(), sqlx::Error> {
         queries::insert_names(&self.pool, names).await
     }
 
@@ -67,7 +67,7 @@ impl DatabaseConnection {
         queries::insert_item(&self.pool, item).await
     }
 
-    pub async fn create_items(&self, items: Vec<ItemRow>) -> Result<(), sqlx::Error> {
+    pub async fn create_items(&self, items: &[ItemRow]) -> Result<(), sqlx::Error> {
         queries::insert_items(&self.pool, items).await
     }
 
@@ -77,7 +77,7 @@ impl DatabaseConnection {
     }
 
     #[allow(dead_code)]
-    pub async fn create_item_lines(&self, item_lines: Vec<ItemLineRow>) -> Result<(), sqlx::Error> {
+    pub async fn create_item_lines(&self, item_lines: &[ItemLineRow]) -> Result<(), sqlx::Error> {
         queries::insert_item_lines(&self.pool, item_lines).await
     }
 
@@ -90,7 +90,7 @@ impl DatabaseConnection {
 
     pub async fn create_requisitions(
         &self,
-        requisitions: Vec<RequisitionRow>,
+        requisitions: &[RequisitionRow],
     ) -> Result<(), sqlx::Error> {
         queries::insert_requisitions(&self.pool, requisitions).await
     }
@@ -104,7 +104,7 @@ impl DatabaseConnection {
 
     pub async fn create_requisition_lines(
         &self,
-        requisition_lines: Vec<RequisitionLineRow>,
+        requisition_lines: &[RequisitionLineRow],
     ) -> Result<(), sqlx::Error> {
         queries::insert_requisition_lines(&self.pool, requisition_lines).await
     }

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -1,5 +1,3 @@
-//! src/database/mod.rs
-
 pub mod connection;
 pub mod mocks;
 pub mod queries;

--- a/src/database/queries.rs
+++ b/src/database/queries.rs
@@ -18,9 +18,9 @@ pub async fn insert_store(pool: &sqlx::PgPool, store: &StoreRow) -> Result<(), s
     Ok(())
 }
 
-pub async fn insert_stores(pool: &sqlx::PgPool, stores: Vec<StoreRow>) -> Result<(), sqlx::Error> {
+pub async fn insert_stores(pool: &sqlx::PgPool, stores: &[StoreRow]) -> Result<(), sqlx::Error> {
     // TODO: aggregate into single query.
-    for store in &stores {
+    for store in stores {
         sqlx::query!(
             r#"
                 INSERT INTO store (id, name_id)
@@ -51,9 +51,9 @@ pub async fn insert_name(pool: &sqlx::PgPool, name: &NameRow) -> Result<(), sqlx
     Ok(())
 }
 
-pub async fn insert_names(pool: &sqlx::PgPool, names: Vec<NameRow>) -> Result<(), sqlx::Error> {
+pub async fn insert_names(pool: &sqlx::PgPool, names: &[NameRow]) -> Result<(), sqlx::Error> {
     // TODO: aggregate into single query.
-    for name in &names {
+    for name in names {
         sqlx::query!(
             r#"
                 INSERT INTO name (id, name)
@@ -84,9 +84,9 @@ pub async fn insert_item(pool: &sqlx::PgPool, item: &ItemRow) -> Result<(), sqlx
     Ok(())
 }
 
-pub async fn insert_items(pool: &sqlx::PgPool, items: Vec<ItemRow>) -> Result<(), sqlx::Error> {
+pub async fn insert_items(pool: &sqlx::PgPool, items: &[ItemRow]) -> Result<(), sqlx::Error> {
     // TODO: aggregate into single query.
-    for item in &items {
+    for item in items {
         sqlx::query!(
             r#"
             INSERT INTO item (id, item_name)
@@ -125,10 +125,10 @@ pub async fn insert_item_line(
 
 pub async fn insert_item_lines(
     pool: &sqlx::PgPool,
-    item_lines: Vec<ItemLineRow>,
+    item_lines: &[ItemLineRow],
 ) -> Result<(), sqlx::Error> {
     // TODO: aggregate into single query.
-    for item_line in &item_lines {
+    for item_line in item_lines {
         sqlx::query!(
             r#"
             INSERT INTO item_line (id, item_id, store_id, batch, quantity)
@@ -169,10 +169,10 @@ pub async fn insert_requisition(
 
 pub async fn insert_requisitions(
     pool: &sqlx::PgPool,
-    requisitions: Vec<RequisitionRow>,
+    requisitions: &[RequisitionRow],
 ) -> Result<(), sqlx::Error> {
     // TODO: aggregate into single query.
-    for requisition in &requisitions {
+    for requisition in requisitions {
         sqlx::query!(
             r#"
             INSERT INTO requisition (id, name_id, store_id, type_of)
@@ -213,10 +213,10 @@ pub async fn insert_requisition_line(
 
 pub async fn insert_requisition_lines(
     pool: &sqlx::PgPool,
-    requisition_lines: Vec<RequisitionLineRow>,
+    requisition_lines: &[RequisitionLineRow],
 ) -> Result<(), sqlx::Error> {
     // TODO: aggregate into single query.
-    for requisition_line in &requisition_lines {
+    for requisition_line in requisition_lines {
         sqlx::query!(
             r#"
             INSERT INTO requisition_line (id, requisition_id, item_id, actual_quantity, suggested_quantity)

--- a/src/database/queries.rs
+++ b/src/database/queries.rs
@@ -1,5 +1,3 @@
-//! src/database/queries.rs
-
 use crate::database::schema::{
     ItemLineRow, ItemRow, NameRow, RequisitionLineRow, RequisitionRow, RequisitionRowType,
     StoreRow, TransactionLineRow, TransactionRow, TransactionRowType,

--- a/src/database/queries.rs
+++ b/src/database/queries.rs
@@ -235,7 +235,7 @@ pub async fn insert_requisition_lines(
     Ok(())
 }
 
-pub async fn select_store(pool: &sqlx::PgPool, id: String) -> Result<StoreRow, sqlx::Error> {
+pub async fn select_store(pool: &sqlx::PgPool, id: &str) -> Result<StoreRow, sqlx::Error> {
     let store = sqlx::query_as!(
         StoreRow,
         r#"
@@ -251,7 +251,7 @@ pub async fn select_store(pool: &sqlx::PgPool, id: String) -> Result<StoreRow, s
     Ok(store)
 }
 
-pub async fn select_name(pool: &sqlx::PgPool, id: String) -> Result<NameRow, sqlx::Error> {
+pub async fn select_name(pool: &sqlx::PgPool, id: &str) -> Result<NameRow, sqlx::Error> {
     let name = sqlx::query_as!(
         NameRow,
         r#"
@@ -267,7 +267,7 @@ pub async fn select_name(pool: &sqlx::PgPool, id: String) -> Result<NameRow, sql
     Ok(name)
 }
 
-pub async fn select_item(pool: &sqlx::PgPool, id: String) -> Result<ItemRow, sqlx::Error> {
+pub async fn select_item(pool: &sqlx::PgPool, id: &str) -> Result<ItemRow, sqlx::Error> {
     let item = sqlx::query_as!(
         ItemRow,
         r#"
@@ -283,7 +283,7 @@ pub async fn select_item(pool: &sqlx::PgPool, id: String) -> Result<ItemRow, sql
     Ok(item)
 }
 
-pub async fn select_item_line(pool: &sqlx::PgPool, id: String) -> Result<ItemLineRow, sqlx::Error> {
+pub async fn select_item_line(pool: &sqlx::PgPool, id: &str) -> Result<ItemLineRow, sqlx::Error> {
     let item_line = sqlx::query_as!(
         ItemLineRow,
         r#"
@@ -301,7 +301,7 @@ pub async fn select_item_line(pool: &sqlx::PgPool, id: String) -> Result<ItemLin
 
 pub async fn select_requisition(
     pool: &sqlx::PgPool,
-    id: String,
+    id: &str,
 ) -> Result<RequisitionRow, sqlx::Error> {
     let requisition = sqlx::query_as!(
         RequisitionRow,
@@ -320,7 +320,7 @@ pub async fn select_requisition(
 
 pub async fn select_requisition_line(
     pool: &sqlx::PgPool,
-    id: String,
+    id: &str,
 ) -> Result<RequisitionLineRow, sqlx::Error> {
     let requisition_line = sqlx::query_as!(
         RequisitionLineRow,
@@ -339,7 +339,7 @@ pub async fn select_requisition_line(
 
 pub async fn select_requisition_lines(
     pool: &sqlx::PgPool,
-    requisition_id: String,
+    requisition_id: &str,
 ) -> Result<Vec<RequisitionLineRow>, sqlx::Error> {
     let requisition_lines = sqlx::query_as!(
         RequisitionLineRow,
@@ -358,7 +358,7 @@ pub async fn select_requisition_lines(
 
 pub async fn select_transaction(
     pool: &sqlx::PgPool,
-    id: String,
+    id: &str,
 ) -> Result<TransactionRow, sqlx::Error> {
     let transaction: TransactionRow = sqlx::query_as!(
         TransactionRow,
@@ -377,7 +377,7 @@ pub async fn select_transaction(
 
 pub async fn select_transactions(
     pool: &sqlx::PgPool,
-    name_id: String,
+    name_id: &str,
 ) -> Result<Vec<TransactionRow>, sqlx::Error> {
     let transactions: Vec<TransactionRow> = sqlx::query_as!(
         TransactionRow,
@@ -396,7 +396,7 @@ pub async fn select_transactions(
 
 pub async fn select_transaction_line(
     pool: &sqlx::PgPool,
-    id: String,
+    id: &str,
 ) -> Result<TransactionLineRow, sqlx::Error> {
     let transaction_line: TransactionLineRow = sqlx::query_as!(
         TransactionLineRow,
@@ -415,7 +415,7 @@ pub async fn select_transaction_line(
 
 pub async fn select_transaction_lines(
     pool: &sqlx::PgPool,
-    transaction_id: String,
+    transaction_id: &str,
 ) -> Result<Vec<TransactionLineRow>, sqlx::Error> {
     let transaction_lines: Vec<TransactionLineRow> = sqlx::query_as!(
         TransactionLineRow,

--- a/src/database/schema.rs
+++ b/src/database/schema.rs
@@ -1,5 +1,3 @@
-//! src/utils/database/schema.rs
-
 #[derive(Clone)]
 pub struct NameRow {
     pub id: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-//! src/main.rs
-
 mod database;
 mod server;
 mod utils;

--- a/src/server/middleware.rs
+++ b/src/server/middleware.rs
@@ -1,5 +1,3 @@
-//! src/server/middleware.rs
-
 pub fn compress() -> actix_web::middleware::Compress {
     actix_web::middleware::Compress::default()
 }

--- a/src/server/services/graphql/config.rs
+++ b/src/server/services/graphql/config.rs
@@ -1,5 +1,3 @@
-//! src/services/graphql/config.rs
-
 use crate::server::services::graphql::routes::{handlers, paths};
 use crate::server::services::graphql::schema::{Mutations, Queries, Schema, Subscriptions};
 

--- a/src/server/services/graphql/mod.rs
+++ b/src/server/services/graphql/mod.rs
@@ -1,5 +1,3 @@
-//! src/services/graphql/mod.rs
-
 pub mod config;
 pub mod routes;
 pub mod schema;

--- a/src/server/services/graphql/routes/handlers.rs
+++ b/src/server/services/graphql/routes/handlers.rs
@@ -1,5 +1,3 @@
-//! src/services/graphql/routes.rs
-
 use crate::database::DatabaseConnection;
 use crate::server::graphql::schema::Schema;
 

--- a/src/server/services/graphql/routes/mod.rs
+++ b/src/server/services/graphql/routes/mod.rs
@@ -1,5 +1,3 @@
-//! src/services/graphql/routes/mod.rs
-
 pub mod handlers;
 pub mod paths;
 

--- a/src/server/services/graphql/routes/paths.rs
+++ b/src/server/services/graphql/routes/paths.rs
@@ -1,3 +1,1 @@
-//! src/services/graphql/routes/paths.rs
-
 pub static GRAPHQL: &str = "/graphql";

--- a/src/server/services/graphql/schema/context.rs
+++ b/src/server/services/graphql/schema/context.rs
@@ -1,5 +1,3 @@
-//! src/services/graphql/context.rs
-
 use crate::database::DatabaseConnection;
 
 impl juniper::Context for DatabaseConnection {}

--- a/src/server/services/graphql/schema/mod.rs
+++ b/src/server/services/graphql/schema/mod.rs
@@ -1,5 +1,3 @@
-//! src/services/graphql/mod.rs
-
 mod context;
 mod mutations;
 mod queries;

--- a/src/server/services/graphql/schema/mutations.rs
+++ b/src/server/services/graphql/schema/mutations.rs
@@ -1,6 +1,4 @@
-use crate::database::{
-    DatabaseConnection, ItemRow, RequisitionLineRow, RequisitionRow, RequisitionRowType,
-};
+use crate::database::{DatabaseConnection, ItemRow, RequisitionLineRow, RequisitionRow};
 use crate::server::graphql::{InputRequisitionLine, Item, Requisition, RequisitionType};
 
 pub struct Mutations;
@@ -40,14 +38,7 @@ impl Mutations {
             id: id.clone(),
             name_id,
             store_id,
-            type_of: match type_of {
-                RequisitionType::Imprest => RequisitionRowType::Imprest,
-                RequisitionType::StockHistory => RequisitionRowType::StockHistory,
-                RequisitionType::Request => RequisitionRowType::Request,
-                RequisitionType::Response => RequisitionRowType::Response,
-                RequisitionType::Supply => RequisitionRowType::Supply,
-                RequisitionType::Report => RequisitionRowType::Report,
-            },
+            type_of: type_of.into(),
         };
 
         database

--- a/src/server/services/graphql/schema/mutations.rs
+++ b/src/server/services/graphql/schema/mutations.rs
@@ -11,10 +11,7 @@ impl Mutations {
         item_name(description = "name of the item"),
     ))]
     async fn insert_item(database: &DatabaseConnection, id: String, item_name: String) -> Item {
-        let item_row = ItemRow {
-            id: id.clone(),
-            item_name: item_name.clone(),
-        };
+        let item_row = ItemRow { id, item_name };
 
         database
             .create_item(&item_row)
@@ -41,8 +38,8 @@ impl Mutations {
     ) -> Requisition {
         let requisition_row = RequisitionRow {
             id: id.clone(),
-            name_id: name_id.clone(),
-            store_id: store_id.clone(),
+            name_id,
+            store_id,
             type_of: match type_of {
                 RequisitionType::Imprest => RequisitionRowType::Imprest,
                 RequisitionType::StockHistory => RequisitionRowType::StockHistory,
@@ -59,7 +56,6 @@ impl Mutations {
             .expect("Failed to insert requisition into database");
 
         let requisition_line_rows: Vec<RequisitionLineRow> = requisition_lines
-            .clone()
             .into_iter()
             .map(|line| RequisitionLineRow {
                 id: line.id,

--- a/src/server/services/graphql/schema/mutations.rs
+++ b/src/server/services/graphql/schema/mutations.rs
@@ -1,5 +1,3 @@
-//! src/services/graphql/mutations.rs
-
 use crate::database::{
     DatabaseConnection, ItemRow, RequisitionLineRow, RequisitionRow, RequisitionRowType,
 };

--- a/src/server/services/graphql/schema/queries.rs
+++ b/src/server/services/graphql/schema/queries.rs
@@ -17,7 +17,7 @@ impl Queries {
     #[graphql(arguments(id(description = "id of the name")))]
     pub async fn name(database: &DatabaseConnection, id: String) -> Name {
         let name_row: NameRow = database
-            .get_name(id.to_string())
+            .get_name(&id)
             .await
             .unwrap_or_else(|_| panic!("Failed to get name {}", id));
 
@@ -27,7 +27,7 @@ impl Queries {
     #[graphql(arguments(id(description = "id of the store")))]
     pub async fn store(database: &DatabaseConnection, id: String) -> Store {
         let store_row: StoreRow = database
-            .get_store(id.to_string())
+            .get_store(&id)
             .await
             .unwrap_or_else(|_| panic!("Failed to get store {}", id));
 
@@ -37,7 +37,7 @@ impl Queries {
     #[graphql(arguments(id(description = "id of the transaction")))]
     pub async fn transaction(database: &DatabaseConnection, id: String) -> Transaction {
         let transaction_row: TransactionRow = database
-            .get_transaction(id.to_string())
+            .get_transaction(&id)
             .await
             .unwrap_or_else(|_| panic!("Failed to get transaction {}", id));
 
@@ -47,7 +47,7 @@ impl Queries {
     #[graphql(arguments(id(description = "id of the transaction line")))]
     pub async fn transaction_line(database: &DatabaseConnection, id: String) -> TransactionLine {
         let transaction_line_row: TransactionLineRow = database
-            .get_transaction_line(id.to_string())
+            .get_transaction_line(&id)
             .await
             .unwrap_or_else(|_| panic!("Failed to get transaction line {}", id));
 
@@ -59,7 +59,7 @@ impl Queries {
     #[graphql(arguments(id(description = "id of the requisition")))]
     pub async fn requisition(database: &DatabaseConnection, id: String) -> Requisition {
         let requisition_row: RequisitionRow = database
-            .get_requisition(id.to_string())
+            .get_requisition(&id)
             .await
             .unwrap_or_else(|_| panic!("Failed to get requisition {}", id));
 
@@ -69,7 +69,7 @@ impl Queries {
     #[graphql(arguments(id(description = "id of the item")))]
     pub async fn item(database: &DatabaseConnection, id: String) -> Item {
         let item_row: ItemRow = database
-            .get_item(id.to_string())
+            .get_item(&id)
             .await
             .unwrap_or_else(|_| panic!("Failed to get item {}", id));
 
@@ -79,7 +79,7 @@ impl Queries {
     #[graphql(arguments(id(description = "id of the item line")))]
     pub async fn item_line(database: &DatabaseConnection, id: String) -> ItemLine {
         let item_line_row: ItemLineRow = database
-            .get_item_line(id.to_string())
+            .get_item_line(&id)
             .await
             .unwrap_or_else(|_| panic!("Failed to get item line {}", id));
 

--- a/src/server/services/graphql/schema/queries.rs
+++ b/src/server/services/graphql/schema/queries.rs
@@ -1,5 +1,3 @@
-//! src/services/graphql/queries.rs
-
 use crate::database::schema::{
     ItemLineRow, ItemRow, NameRow, RequisitionRow, StoreRow, TransactionLineRow, TransactionRow,
 };

--- a/src/server/services/graphql/schema/subscriptions.rs
+++ b/src/server/services/graphql/schema/subscriptions.rs
@@ -1,5 +1,3 @@
-//! src/services/graphql/subscriptions.rs
-
 use crate::database::DatabaseConnection;
 
 pub type Subscriptions = juniper::EmptySubscription<DatabaseConnection>;

--- a/src/server/services/graphql/schema/types.rs
+++ b/src/server/services/graphql/schema/types.rs
@@ -7,7 +7,6 @@ use crate::database::DatabaseConnection;
 use juniper::{graphql_object, GraphQLEnum, GraphQLInputObject};
 
 #[derive(Clone)]
-// A name.
 pub struct Name {
     pub name_row: NameRow,
 }
@@ -24,7 +23,6 @@ impl Name {
 }
 
 #[derive(Clone)]
-// A store.
 pub struct Store {
     pub store_row: StoreRow,
 }
@@ -46,7 +44,6 @@ impl Store {
 }
 
 #[derive(Clone)]
-// An item.
 pub struct Item {
     pub item_row: ItemRow,
 }
@@ -63,7 +60,6 @@ impl Item {
 }
 
 #[derive(Clone)]
-// An item line.
 pub struct ItemLine {
     pub item_line_row: ItemLineRow,
 }
@@ -125,7 +121,6 @@ pub enum RequisitionType {
 }
 
 #[derive(Clone)]
-// A requisition.
 pub struct Requisition {
     pub requisition_row: RequisitionRow,
 }
@@ -196,7 +191,6 @@ impl Requisition {
 }
 
 #[derive(Clone)]
-// A requisition line.
 pub struct RequisitionLine {
     pub requisition_line_row: RequisitionLineRow,
 }
@@ -251,7 +245,6 @@ pub enum TransactionType {
 }
 
 #[derive(Clone)]
-// A transaction.
 pub struct Transaction {
     pub transaction_row: TransactionRow,
 }
@@ -314,7 +307,6 @@ impl Transaction {
 }
 
 #[derive(Clone)]
-// A transaction line
 pub struct TransactionLine {
     pub transaction_line_row: TransactionLineRow,
 }
@@ -370,7 +362,6 @@ impl TransactionLine {
 }
 
 #[derive(Clone, GraphQLInputObject)]
-// A input requisition line.
 pub struct InputRequisitionLine {
     pub id: String,
     pub item_id: String,

--- a/src/server/services/graphql/schema/types.rs
+++ b/src/server/services/graphql/schema/types.rs
@@ -14,12 +14,12 @@ pub struct Name {
 
 #[graphql_object(Context = DatabaseConnection)]
 impl Name {
-    pub fn id(&self) -> String {
-        self.name_row.id.clone()
+    pub fn id(&self) -> &str {
+        &self.name_row.id
     }
 
-    pub fn name(&self) -> String {
-        self.name_row.id.clone()
+    pub fn name(&self) -> &str {
+        &self.name_row.id
     }
 }
 
@@ -31,13 +31,13 @@ pub struct Store {
 
 #[graphql_object(Context = DatabaseConnection)]
 impl Store {
-    pub fn id(&self) -> String {
-        self.store_row.id.clone()
+    pub fn id(&self) -> &str {
+        &self.store_row.id
     }
 
     pub async fn name(&self, database: &DatabaseConnection) -> Name {
         let name_row = database
-            .get_name(self.store_row.name_id.clone())
+            .get_name(&self.store_row.name_id)
             .await
             .unwrap_or_else(|_| panic!("Failed to get name for transaction {}", self.store_row.id));
 
@@ -53,12 +53,12 @@ pub struct Item {
 
 #[graphql_object(Context = DatabaseConnection)]
 impl Item {
-    pub fn id(&self) -> String {
-        self.item_row.id.clone()
+    pub fn id(&self) -> &str {
+        &self.item_row.id
     }
 
-    pub fn item_name(&self) -> String {
-        self.item_row.item_name.clone()
+    pub fn item_name(&self) -> &str {
+        &self.item_row.item_name
     }
 }
 
@@ -70,13 +70,13 @@ pub struct ItemLine {
 
 #[graphql_object(Context = DatabaseConnection)]
 impl ItemLine {
-    pub fn id(&self) -> String {
-        self.item_line_row.id.clone()
+    pub fn id(&self) -> &str {
+        &self.item_line_row.id
     }
 
     pub async fn item(&self, database: &DatabaseConnection) -> Item {
         let item_row = database
-            .get_item(self.item_line_row.item_id.clone())
+            .get_item(&self.item_line_row.item_id)
             .await
             .unwrap_or_else(|_| {
                 panic!("Failed to get item for item line {}", self.item_line_row.id)
@@ -87,7 +87,7 @@ impl ItemLine {
 
     pub async fn store(&self, database: &DatabaseConnection) -> Store {
         let store_row = database
-            .get_store(self.item_line_row.store_id.clone())
+            .get_store(&self.item_line_row.store_id)
             .await
             .unwrap_or_else(|_| {
                 panic!(
@@ -99,8 +99,8 @@ impl ItemLine {
         Store { store_row }
     }
 
-    pub fn batch(&self) -> String {
-        self.item_line_row.batch.clone()
+    pub fn batch(&self) -> &str {
+        &self.item_line_row.batch
     }
 
     pub fn quantity(&self) -> f64 {
@@ -132,13 +132,13 @@ pub struct Requisition {
 
 #[graphql_object(Context = DatabaseConnection)]
 impl Requisition {
-    pub fn id(&self) -> String {
-        self.requisition_row.id.clone()
+    pub fn id(&self) -> &str {
+        &self.requisition_row.id
     }
 
     pub async fn name(&self, database: &DatabaseConnection) -> Name {
         let name_row = database
-            .get_name(self.requisition_row.name_id.clone())
+            .get_name(&self.requisition_row.name_id)
             .await
             .unwrap_or_else(|_| {
                 panic!(
@@ -152,7 +152,7 @@ impl Requisition {
 
     pub async fn store(&self, database: &DatabaseConnection) -> Store {
         let store_row = database
-            .get_store(self.requisition_row.store_id.clone())
+            .get_store(&self.requisition_row.store_id)
             .await
             .unwrap_or_else(|_| {
                 panic!(
@@ -177,7 +177,7 @@ impl Requisition {
 
     pub async fn requisition_lines(&self, database: &DatabaseConnection) -> Vec<RequisitionLine> {
         let requisition_line_rows = database
-            .get_requisition_lines(self.requisition_row.id.clone())
+            .get_requisition_lines(&self.requisition_row.id)
             .await
             .unwrap_or_else(|_| {
                 panic!(
@@ -203,13 +203,13 @@ pub struct RequisitionLine {
 
 #[graphql_object(Context = DatabaseConnection)]
 impl RequisitionLine {
-    pub fn id(&self) -> String {
-        self.requisition_line_row.id.clone()
+    pub fn id(&self) -> &str {
+        &self.requisition_line_row.id
     }
 
     pub async fn item(&self, database: &DatabaseConnection) -> Item {
         let item_row = database
-            .get_item(self.requisition_line_row.item_id.clone())
+            .get_item(&self.requisition_line_row.item_id)
             .await
             .unwrap_or_else(|_| {
                 panic!(
@@ -264,7 +264,7 @@ impl Transaction {
 
     pub async fn name(&self, database: &DatabaseConnection) -> Name {
         let name_row = database
-            .get_name(self.transaction_row.name_id.clone())
+            .get_name(&self.transaction_row.name_id)
             .await
             .unwrap_or_else(|_| {
                 panic!(
@@ -295,7 +295,7 @@ impl Transaction {
 
     pub async fn transaction_lines(&self, database: &DatabaseConnection) -> Vec<TransactionLine> {
         let transaction_line_rows: Vec<TransactionLineRow> = database
-            .get_transaction_lines(self.transaction_row.id.clone())
+            .get_transaction_lines(&self.transaction_row.id)
             .await
             .unwrap_or_else(|_| {
                 panic!(
@@ -321,13 +321,13 @@ pub struct TransactionLine {
 
 #[graphql_object(Context = DatabaseConnection)]
 impl TransactionLine {
-    pub fn id(&self) -> String {
-        self.transaction_line_row.id.clone()
+    pub fn id(&self) -> &str {
+        &self.transaction_line_row.id
     }
 
     pub async fn transaction(&self, database: &DatabaseConnection) -> Transaction {
         let transaction_row: TransactionRow = database
-            .get_transaction(self.transaction_line_row.transaction_id.clone())
+            .get_transaction(&self.transaction_line_row.transaction_id)
             .await
             .unwrap_or_else(|_| {
                 panic!(
@@ -341,7 +341,7 @@ impl TransactionLine {
 
     pub async fn item(&self, database: &DatabaseConnection) -> Item {
         let item_row = database
-            .get_item(self.transaction_line_row.item_id.clone())
+            .get_item(&self.transaction_line_row.item_id)
             .await
             .unwrap_or_else(|_| {
                 panic!(
@@ -356,7 +356,7 @@ impl TransactionLine {
     pub async fn item_line(&self, database: &DatabaseConnection) -> ItemLine {
         // Handle optional item_line_id correctly.
         let item_line_row = database
-            .get_item_line(self.transaction_line_row.item_line_id.clone().unwrap())
+            .get_item_line(self.transaction_line_row.item_line_id.as_ref().unwrap())
             .await
             .unwrap_or_else(|_| {
                 panic!(

--- a/src/server/services/graphql/schema/types.rs
+++ b/src/server/services/graphql/schema/types.rs
@@ -120,6 +120,32 @@ pub enum RequisitionType {
     Report,
 }
 
+impl From<RequisitionRowType> for RequisitionType {
+    fn from(requisition_row_type: RequisitionRowType) -> RequisitionType {
+        match requisition_row_type {
+            RequisitionRowType::Imprest => RequisitionType::Imprest,
+            RequisitionRowType::StockHistory => RequisitionType::StockHistory,
+            RequisitionRowType::Request => RequisitionType::Request,
+            RequisitionRowType::Response => RequisitionType::Response,
+            RequisitionRowType::Supply => RequisitionType::Supply,
+            RequisitionRowType::Report => RequisitionType::Report,
+        }
+    }
+}
+
+impl From<RequisitionType> for RequisitionRowType {
+    fn from(requisition_type: RequisitionType) -> RequisitionRowType {
+        match requisition_type {
+            RequisitionType::Imprest => RequisitionRowType::Imprest,
+            RequisitionType::StockHistory => RequisitionRowType::StockHistory,
+            RequisitionType::Request => RequisitionRowType::Request,
+            RequisitionType::Response => RequisitionRowType::Response,
+            RequisitionType::Supply => RequisitionRowType::Supply,
+            RequisitionType::Report => RequisitionRowType::Report,
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct Requisition {
     pub requisition_row: RequisitionRow,

--- a/src/server/services/graphql/schema/types.rs
+++ b/src/server/services/graphql/schema/types.rs
@@ -1,5 +1,3 @@
-//! src/services/graphql/schema/types.rs
-
 use crate::database::schema::{
     ItemLineRow, ItemRow, NameRow, RequisitionLineRow, RequisitionRow, RequisitionRowType,
     StoreRow, TransactionLineRow, TransactionRow, TransactionRowType,

--- a/src/server/services/mod.rs
+++ b/src/server/services/mod.rs
@@ -1,5 +1,3 @@
-//! src/services/mod.rs
-
 pub mod graphql;
 pub mod rest;
 

--- a/src/server/services/rest/config.rs
+++ b/src/server/services/rest/config.rs
@@ -1,5 +1,3 @@
-//! src/services/rest/config.rs
-
 use crate::server::rest::routes;
 
 pub fn config(cfg: &mut actix_web::web::ServiceConfig) {

--- a/src/server/services/rest/mod.rs
+++ b/src/server/services/rest/mod.rs
@@ -1,5 +1,3 @@
-//! src/services/rest/mod.rs
-
 pub mod config;
 pub mod routes;
 

--- a/src/server/services/rest/routes/handlers.rs
+++ b/src/server/services/rest/routes/handlers.rs
@@ -1,5 +1,3 @@
-//! src/services/rest/routes/handlers.rs
-
 pub async fn health_check(
     _req: actix_web::HttpRequest,
 ) -> Result<actix_web::HttpResponse, actix_web::Error> {

--- a/src/server/services/rest/routes/mod.rs
+++ b/src/server/services/rest/routes/mod.rs
@@ -1,5 +1,3 @@
-//! src/services/rest/routes/mod.rs
-
 pub mod handlers;
 pub mod paths;
 

--- a/src/server/services/rest/routes/paths.rs
+++ b/src/server/services/rest/routes/paths.rs
@@ -1,3 +1,1 @@
-//! src/services/rest/routes/paths.rs
-
 pub static HEALTH_CHECK: &str = "/health_check";

--- a/src/utils/configuration.rs
+++ b/src/utils/configuration.rs
@@ -1,5 +1,3 @@
-//! src/utils/configuration.rs
-
 use crate::utils::{Environment, Settings};
 use std::borrow::Cow;
 

--- a/src/utils/configuration.rs
+++ b/src/utils/configuration.rs
@@ -2,8 +2,6 @@
 
 use crate::utils::{Environment, Settings};
 
-use std::convert::TryInto;
-
 pub fn get_configuration() -> Result<Settings, config::ConfigError> {
     let mut settings = config::Config::default();
     let base_path = std::env::current_dir().expect("Failed to determine current directory");
@@ -13,7 +11,7 @@ pub fn get_configuration() -> Result<Settings, config::ConfigError> {
 
     let environment: Environment = std::env::var("APP_ENVIRONMENT")
         .unwrap_or_else(|_| "local".into())
-        .try_into()
+        .parse()
         .expect("Failed to parse APP_ENVIRONMENT");
 
     settings.merge(

--- a/src/utils/configuration.rs
+++ b/src/utils/configuration.rs
@@ -1,6 +1,7 @@
 //! src/utils/configuration.rs
 
 use crate::utils::{Environment, Settings};
+use std::borrow::Cow;
 
 pub fn get_configuration() -> Result<Settings, config::ConfigError> {
     let mut settings = config::Config::default();
@@ -10,6 +11,7 @@ pub fn get_configuration() -> Result<Settings, config::ConfigError> {
     settings.merge(config::File::from(configuration_directory.join("base")).required(true))?;
 
     let environment: Environment = std::env::var("APP_ENVIRONMENT")
+        .map(Cow::from)
         .unwrap_or_else(|_| "local".into())
         .parse()
         .expect("Failed to parse APP_ENVIRONMENT");

--- a/src/utils/environment.rs
+++ b/src/utils/environment.rs
@@ -1,6 +1,7 @@
 //! src/utils/environment.rs
 
-use std::convert::TryFrom;
+use std::str::FromStr;
+
 pub enum Environment {
     Local,
     Production,
@@ -15,17 +16,19 @@ impl Environment {
     }
 }
 
-impl TryFrom<String> for Environment {
-    type Error = String;
+impl FromStr for Environment {
+    type Err = String;
 
-    fn try_from(s: String) -> Result<Self, Self::Error> {
-        match s.to_lowercase().as_str() {
-            "local" => Ok(Self::Local),
-            "production" => Ok(Self::Production),
-            other => Err(format!(
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.eq_ignore_ascii_case("local") {
+            Ok(Self::Local)
+        } else if s.eq_ignore_ascii_case("production") {
+            Ok(Self::Production)
+        } else {
+            Err(format!(
                 "{} is not a supported environment. Use either `local` or `production`.",
-                other
-            )),
+                s
+            ))
         }
     }
 }

--- a/src/utils/environment.rs
+++ b/src/utils/environment.rs
@@ -1,5 +1,3 @@
-//! src/utils/environment.rs
-
 use std::str::FromStr;
 
 pub enum Environment {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,5 +1,3 @@
-//! src/utils/mod.rs
-
 pub mod configuration;
 pub mod environment;
 pub mod settings;

--- a/src/utils/settings.rs
+++ b/src/utils/settings.rs
@@ -1,5 +1,3 @@
-//! src/utils/settings.rs
-
 #[derive(serde::Deserialize)]
 pub struct Settings {
     pub server: ServerSettings,


### PR DESCRIPTION
As mentioned, there are currently conflicts but you suggested that I leave the rebasing to you rather than doing it myself (but ask me and I can do it readily enough).

Notes are mostly on the commits. Here are the other notes I made:

src/utils/environment.rs:18, better to avoid String, use FromStr instead of TryFrom<String>.

src/utils/configuration.rs:15, "local".into() is a strictly unnecessary allocation of a String, though this being a one-off thing and the ergonomics of Cow being what they are I generally wouldn’t worry, but the teaching opportunity is good—Cow is worth knowing about. In this instance it ends up a surprisingly painless alteration, but it’s still a technical distraction from the logic, and thus potentially unwarranted.

Good stuff on using .expect(message) rather than .unwrap().

mod.rs files are commonly using `pub mod foo; pub use self::foo::*;`. This exposes the things at two paths. I recommend going one way or the other in each case, either using that module for local structure (`mod foo; pub use self::foo::*;`) or for namespacing (`pub mod foo;`). You can definitely mix the two; tooling should make that pretty painless. But having multiple paths to the one object means you have to keep deciding which to use. (In other news, I’ve become progressively less and less convinced of the wisdom of the last line of the Zen of Python.)

The code base has mod.rs files that are almost exclusively just `mod` and `use` statements. Some of the inner modules, then, are almost empty (e.g. src/server/services/graphql/schema/subscriptions.rs) or even empty (e.g. src/server/services/graphql/schema/subscriptions.rs which is just an impl). I suggest merging at least some of those into the mod.rs file. In the case of src/server/services/graphql/schema/mod.rs, I’d merge context.rs into mod.rs. I can see that types, queries and mutations have value in being separated for code organisation purposes, and I suppose it then makes sense for subscriptions to stay separate in like manner.

Look for places where you take String, and see if you can take &str. Gratuitous cloning is the sort of thing that *can* end up with Rust code performing worse than other languages, though you tend to have to go quite some way before it gets that bad.

src/server/services/graphql/schema/types.rs: lots of effective duplication here, *might* be worth looking into using macros, though probably not at this exploratory/experimental stage.
